### PR TITLE
[REF] odootil: name_search_multi_leaf

### DIFF
--- a/odootil/__manifest__.py
+++ b/odootil/__manifest__.py
@@ -7,7 +7,7 @@
     'license': 'OEEL-1',
     'author': "Focusate",
     'website': "http://www.focusate.eu",
-    'category': 'Technical/Tools',
+    'category': 'Hidden/Tools',
     'depends': [
         'web'
     ],

--- a/odootil/models/base.py
+++ b/odootil/models/base.py
@@ -183,6 +183,10 @@ class Base(models.AbstractModel):
 
         For arguments related with get_name_search_domain, see its
         docstring.
+
+        Returns:
+            list of ids
+
         """
         domain = get_name_search_domain(
             name,
@@ -192,9 +196,7 @@ class Base(models.AbstractModel):
             operator=operator
         )
         uid = name_get_uid or self._uid
-        ids = self._search(domain, limit=limit, access_rights_uid=uid)
-        recs = self.browse(ids)
-        return models.lazy_name_get(recs.with_user(uid))
+        return self._search(domain, limit=limit, access_rights_uid=uid)
 
     # orderby transformation helpers.
 
@@ -399,8 +401,10 @@ class Base(models.AbstractModel):
 
         Args:
             fname (str): selection field name
+
         Returns:
             OrderedDict: selection mapping in OrderedDict form.
+
         """
         return collections.OrderedDict(self._fields[fname].selection)
 

--- a/odootil/tests/test_search_helpers.py
+++ b/odootil/tests/test_search_helpers.py
@@ -63,10 +63,9 @@ class TestSearchHelpers(TestOdootilCommon):
 
     def test_03_name_search_multi_leaf(self):
         """Search partners using name_search_multi_leaf."""
-        res = self.ResPartner.name_search_multi_leaf(
+        query_obj = self.ResPartner.name_search_multi_leaf(
             self.partner_1_name,
             ['name'],
             args=self.partner_1_search_args,
             operator='=')
-        self.assertEqual(len(res), 1)
-        self.assertEqual(res[0][0], self.partner_1.id)
+        self.assertEqual(self.ResPartner.browse(query_obj), self.partner_1)

--- a/rest_client/__manifest__.py
+++ b/rest_client/__manifest__.py
@@ -7,7 +7,7 @@
     'license': 'OEEL-1',
     'author': "Focusate",
     'website': "http://www.focusate.eu",
-    'category': 'Technical/Tools',
+    'category': 'Hidden/Tools',
     'depends': [
         'odootil'
     ],


### PR DESCRIPTION
Odoo no longer uses lazy_name_get for search. Instead it used Query
object. Adapted method to reflect that.

[BRANCH] feature/odootil-imp

[Builds](https://www.odoo.sh/project/focusate-misc/builds)
